### PR TITLE
Add Express type annotations for fibRoute (fixes it)

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,8 +1,9 @@
 // Endpoint for querying the fibonacci numbers
 
+import Express from "express";
 import fibonacci from "./fib";
 
-export default (req, res) => {
+export default (req: Express.Request, res : Express.Response) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
Fixes eslint errors by importing the types from Express, and then typing the request and response arguments accordingly. Tested via eslint CI.